### PR TITLE
Revert "Support running the environment on Windows"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3830,58 +3830,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-env": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
-      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.1"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "homepage": "https://draw.rknoll.at",
   "main": "index.js",
   "scripts": {
-    "build": "cross-env NODE_ENV=production webpack --config webpack.prod.js",
+    "build": "NODE_ENV=production webpack --config webpack.prod.js",
     "dev": "run-p dev:*",
     "dev:client": "webpack serve --config webpack.dev.js",
-    "dev:server": "cross-env NODE_ENV=development nodemon --config nodemon.json index.js",
-    "start": "cross-env NODE_ENV=production node -r dotenv-defaults/config index.js",
+    "dev:server": "NODE_ENV=development nodemon --config nodemon.json index.js",
+    "start": "NODE_ENV=production node -r dotenv-defaults/config index.js",
     "bundle-report": "webpack-bundle-analyzer --port 4200 stats.json"
   },
   "author": {
@@ -25,7 +25,6 @@
     "classnames": "^2.2.6",
     "color-parse": "^1.4.2",
     "connected-react-router": "^6.8.0",
-    "cross-env": "^7.0.2",
     "css-loader": "^5.0.0",
     "dotenv-webpack": "^4.0.0",
     "favicons-webpack-plugin": "^4.2.0",


### PR DESCRIPTION
Reverts rknoll/draw#14

Whoops, should have reviewed more carefully, `cross-env` is a regular dependency, not a dev-dependency as it's used at runtime by the server. We remove all dev-dependencies after the build step to keep the final docker image small.