### PR TITLE
Make colour selections more clear

### DIFF
--- a/client/components/Controls.js
+++ b/client/components/Controls.js
@@ -63,7 +63,6 @@ const Controls = ({ tool, updateTool, sendCommand }) => {
   const bottomRow = COLORS.slice(COLORS.length / 2, COLORS.length);
 
   const renderColor = (color) => {
-    const style = { backgroundColor: color };
     const borderStyle = {};
     if (tool.color !== color) borderStyle.borderColor = 'transparent';
     return <div
@@ -73,7 +72,7 @@ const Controls = ({ tool, updateTool, sendCommand }) => {
         <div
           key={color}
           className={classes.color}
-          style={style}
+          style={{backgroundColor: color}}
           onClick={() => updateTool({ color })}
         />
       </div>;

--- a/client/components/Controls.js
+++ b/client/components/Controls.js
@@ -33,6 +33,13 @@ const useStyles = makeStyles((theme) => ({
       height: 40,
     },
   },
+  color: {
+    width: '90%',
+    height: '90%',
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: theme.palette.text.primary,
+  },
   line: {
     borderRadius: '50%',
     backgroundColor: theme.palette.text.primary,
@@ -57,13 +64,19 @@ const Controls = ({ tool, updateTool, sendCommand }) => {
 
   const renderColor = (color) => {
     const style = { backgroundColor: color };
-    if (tool.color !== color) style.borderColor = 'transparent';
+    const borderStyle = {};
+    if (tool.color !== color) borderStyle.borderColor = 'transparent';
     return <div
       key={color}
       className={classes.tool}
-      style={style}
-      onClick={() => updateTool({ color })}
-    />;
+      style={borderStyle}>
+        <div
+          key={color}
+          className={classes.color}
+          style={style}
+          onClick={() => updateTool({ color })}
+        />
+      </div>;
   };
 
   const renderLine = (thickness) => {


### PR DESCRIPTION
* adds an always-on border on each colour (white blends into the
  background on non-dark-mode)
* adds additional border (separated by whitespace) around selected
  colour.

This should make things more clear for the colours that blend in with
the border.

Previews:
* desktop (light mode) before:
  https://user-images.githubusercontent.com/570079/99196588-60888900-275b-11eb-9e3f-ee9faecad714.png
* desktop (light mode) after:
  https://user-images.githubusercontent.com/570079/99196602-6ed6a500-275b-11eb-96bc-416628384afb.png
* desktop (light mode) all borders before:
  https://user-images.githubusercontent.com/570079/99196609-801fb180-275b-11eb-9e8f-c0d1fed4d345.png
* desktop (light mode) all borders after:
  https://user-images.githubusercontent.com/570079/99196615-87df5600-275b-11eb-8553-bf44cd085a8a.png
* mobile (dark mode) before:
  https://user-images.githubusercontent.com/570079/99196672-ead0ed00-275b-11eb-98bc-174022feeeef.png
* mobile (dark mode) after:
  https://user-images.githubusercontent.com/570079/99196806-aa25a380-275c-11eb-85f6-c57e4ebb3664.png
* mobile (dark mode) all borders before:
  https://user-images.githubusercontent.com/570079/99196691-0cca6f80-275c-11eb-942e-b18eb9e56b8a.png
* mobile (dark mode) all borders after:
  https://user-images.githubusercontent.com/570079/99196701-1c49b880-275c-11eb-828e-0f0f78e02120.png

Fixes https://github.com/rknoll/draw/issues/18.