### PR TITLE
Introduce Snackbar API

### DIFF
--- a/client/components/App.js
+++ b/client/components/App.js
@@ -9,6 +9,7 @@ import LandingPage from './LandingPage';
 import GamePage from './GamePage';
 import UserNameDialog from './UserNameDialog';
 import WordSelectionDialog from './WordSelectionDialog';
+import Snackbars from './Snackbars';
 
 export default ({ history }) => {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
@@ -22,6 +23,7 @@ export default ({ history }) => {
       </Switch>
       <UserNameDialog />
       <WordSelectionDialog />
+      <Snackbars />
     </ThemeProvider>
   </ConnectedRouter>;
 }

--- a/client/components/ShareButton.js
+++ b/client/components/ShareButton.js
@@ -1,92 +1,78 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { connect } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import ShareIcon from '@material-ui/icons/Share';
-import Snackbar from '@material-ui/core/Snackbar';
-import MuiAlert from '@material-ui/lab/Alert';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
+import snackbarActions from '../store/actions/snackbars';
 
-const useStyles = ((canShare) => makeStyles((theme) => ({
+const useStyles = makeStyles((theme) => ({
   button: {
     marginTop: 'auto',
     marginBottom: 'auto',
-    display: canShare ? 'inline-flex' : 'none',
     [theme.breakpoints.down('xs')]: {
       position: 'absolute',
       bottom: 12,
       right: 12,
     },
   },
-})));
+}));
 
-export default () => {
-  const [state, setState] = useState({showSnackbar: false});
-  const shareData = {url: window.location.href};
+const ShareButton = ({ showSnackbar }) => {
+  const classes = useStyles();
+  const shareData = { url: window.location.href };
   const canShare = navigator.canShare && navigator.canShare(shareData);
   const canCopy = navigator.clipboard && navigator.clipboard.writeText;
-  const classes = useStyles(canShare || canCopy)();
 
-  const showSuccess = (message) => setState({
-    ...state,
-    snackbarMessage: message,
-    showSnackbar: true,
-    snackbarAutoHideDuration: 1500,
-    snackbarSeverity: 'success'
-  });
-  const showError = (message) => setState({
-    ...state,
-    snackbarMessage: message,
-    showSnackbar: true,
-    snackbarAutoHideDuration: 3000,
-    snackbarSeverity: 'error'
-  });
-
-  const share = async (shareData) => {
-    try {
-      await navigator.share(shareData);
-    } catch (e) {
-      if (e.name !== 'AbortError') {
-        // Failure wasn't due to the user deciding to cancel the share.
-        showError(`Failed to share: ${e.toString()}`);
+  if (canShare) {
+    const shareUrl = async () => {
+      try {
+        await navigator.share(shareData);
+      } catch (e) {
+        if (e.name !== 'AbortError') {
+          // Failure wasn't due to the user deciding to cancel the share.
+          showSnackbar({ message: `Failed to share: ${e.toString()}`, severity: 'error' });
+        }
       }
-    }
-  };
+    };
 
-  const copyUrl = async () => {
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      showSuccess('Copied link!');
-    } catch (e) {
-      showError(`Failed to copy link: ${e.toString()}`);
-    }
-  };
+    return <Button
+      variant='contained'
+      color='primary'
+      className={classes.button}
+      startIcon={<ShareIcon />}
+      onClick={shareUrl}
+    >
+      Share
+    </Button>;
+  }
 
-  const icon = canShare ? <ShareIcon /> : <FileCopyIcon />;
-  const buttonText = canShare ? 'Share' : 'Copy Link';
-  const buttonAction = canShare ? () => share(shareData) : copyUrl;
-  const closeSnackbar = () => setState({...state, showSnackbar: false});
-  return <div>
-      <Button
-        variant='contained'
-        color='primary'
-        startIcon={icon}
-        className={classes.button}
-        onClick={buttonAction}
-      >
-        {buttonText}
-      </Button>
-      <Snackbar
-        open={state.showSnackbar}
-        autoHideDuration={state.snackbarAutoHideDuration}
-        onClose={closeSnackbar}
-      >
-        <MuiAlert
-          variant='filled'
-          onClose={closeSnackbar}
-          severity={state.snackbarSeverity}
-        >
-          {state.snackbarMessage}
-        </MuiAlert>
-      </Snackbar>
-    </div>
+  if (canCopy) {
+    const copyUrl = async () => {
+      try {
+        await navigator.clipboard.writeText(window.location.href);
+        showSnackbar({ message: 'Copied link!', severity: 'success' });
+      } catch (e) {
+        showSnackbar({ message: `Failed to copy link: ${e.toString()}`, severity: 'error' });
+      }
+    };
+
+    return <Button
+      variant='contained'
+      color='primary'
+      className={classes.button}
+      startIcon={<FileCopyIcon />}
+      onClick={copyUrl}
+    >
+      Copy Link
+    </Button>;
+  }
+
+  return null;
 };
+
+const mapDispatchToProps = {
+  showSnackbar: snackbarActions.show,
+};
+
+export default connect(null, mapDispatchToProps)(ShareButton);

--- a/client/components/Snackbars.js
+++ b/client/components/Snackbars.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import Snackbar from '@material-ui/core/Snackbar';
+import MuiAlert from '@material-ui/lab/Alert';
+import snackbarActions from '../store/actions/snackbars';
+
+const Snackbars = ({ snackbars, hideSnackbar, removeSnackbar }) => {
+  const handleHideSnackbar = (event, reason) => {
+    if (reason !== 'clickaway') hideSnackbar();
+  };
+
+  return snackbars.map(({ data, show }, index) => <Snackbar
+    key={index}
+    open={show}
+    autoHideDuration={data.severity === 'success' ? 1500 : 3000}
+    onClose={handleHideSnackbar}
+    onExited={removeSnackbar}
+  >
+    <MuiAlert
+      variant='filled'
+      onClose={handleHideSnackbar}
+      severity={data.severity}
+    >
+      {data.message}
+    </MuiAlert>
+  </Snackbar>);
+};
+
+const mapStateToProps = (state) => ({
+  snackbars: state.snackbars,
+});
+
+const mapDispatchToProps = {
+  hideSnackbar: snackbarActions.hide,
+  removeSnackbar: snackbarActions.remove,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Snackbars);

--- a/client/store/actions/snackbars.js
+++ b/client/store/actions/snackbars.js
@@ -1,0 +1,20 @@
+import actionTypes from '../../decorators/actionTypes';
+
+export const types = actionTypes('snackbars')({
+  SHOW: 'SHOW',
+  HIDE: 'HIDE',
+  REMOVE: 'REMOVE',
+});
+
+export default {
+  show: (data) => ({
+    type: types.SHOW,
+    data,
+  }),
+  hide: () => ({
+    type: types.HIDE,
+  }),
+  remove: () => ({
+    type: types.REMOVE,
+  }),
+};

--- a/client/store/reducers/index.js
+++ b/client/store/reducers/index.js
@@ -3,10 +3,12 @@ import { connectRouter } from 'connected-react-router'
 import game from './game';
 import user from './user';
 import tool from './tool';
+import snackbars from './snackbars';
 
 export default (history) => combineReducers({
   router: connectRouter(history),
   game,
   user,
   tool,
+  snackbars,
 });

--- a/client/store/reducers/snackbars.js
+++ b/client/store/reducers/snackbars.js
@@ -1,0 +1,23 @@
+import { types } from '../actions/snackbars';
+
+export default (state = [], action) => {
+  switch (action.type) {
+    case types.SHOW: {
+      const newState = [...state, { data: action.data, show: false }];
+      if (newState.length === 1) newState[0].show = true;
+      return newState;
+    }
+    case types.HIDE: {
+      const newState = [...state];
+      if (newState.length > 0) newState[0].show = false;
+      return newState;
+    }
+    case types.REMOVE: {
+      const newState = state.slice(1);
+      if (newState.length > 0) newState[0].show = true;
+      return newState;
+    }
+    default:
+      return state;
+  }
+};


### PR DESCRIPTION
This allows components to trigger snackbars which will be queued
and shown one at a time to the user. Converts the ShareButton
component to use this API and remove local state while doing so.