### PR TITLE
Implement end game

### DIFF
--- a/client/store/actions/game.js
+++ b/client/store/actions/game.js
@@ -21,6 +21,7 @@ export const types = actionTypes('game')({
   OTHER_CORRECT_GUESS: 'OTHER_CORRECT_GUESS',
   ROUND_TIME: 'ROUND_TIME',
   CLOSE_GUESS: 'CLOSE_GUESS',
+  GAME_OVER: 'GAME_OVER',
 });
 
 export default {
@@ -108,5 +109,9 @@ export default {
   roundTime: (roundTime) => ({
     type: types.ROUND_TIME,
     roundTime,
+  }),
+  gameOver: (data) => ({
+    type: types.GAME_OVER,
+    ...data,
   }),
 };

--- a/client/store/reducers/game.js
+++ b/client/store/reducers/game.js
@@ -182,6 +182,35 @@ export default (state = initialState, action) => {
       }
       return nextState;
     }
+    case types.GAME_OVER: {
+      let nextState = {
+        ...state,
+        starting: false,
+        started: false,
+        commands: action.commands,
+        words: [],
+        currentWord: '',
+        selectedWord: '',
+        currentPlayer: '',
+        correct: [],
+        points: action.points,
+        roundTime: 0,
+      };
+      switch (action.meta.reason) {
+        case 'SUCCESS':
+          nextState = addMessage(nextState, { type: 'ALL_GUESSED', correct: true });
+          break;
+        case 'FAILED_GUESS':
+          nextState = addMessage(nextState, { type: 'FAILED_GUESS', word: action.meta.word });
+          break;
+        case 'LEAVE':
+          nextState = addMessage(nextState, { type: 'LEAVE_TURN', name: action.meta.name });
+          break;
+        default:
+          break;
+      }
+      return nextState;
+    }
     case types.RESET:
       return {
         ...state,

--- a/client/store/sagas/game.js
+++ b/client/store/sagas/game.js
@@ -55,6 +55,7 @@ export function* subscribe(socket) {
       emit(gameActions.correctGuess(guess));
     });
     socket.on(protocol.NEXT_ROUND, (data) => emit(gameActions.nextRound(data)));
+    socket.on(protocol.GAME_OVER, (data) => emit(gameActions.gameOver(data)));
     socket.on('disconnect', () => emit(gameActions.exitGame()));
     return () => {};
   });

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "git-revision-webpack-plugin": "^3.0.6",
     "history": "^4.10.1",
     "html-webpack-plugin": "^4.5.0",
-    "moment": "^2.29.1",
     "nodemon": "^2.0.6",
     "npm-run-all": "^4.1.5",
     "react": "^16.14.0",
@@ -76,6 +75,7 @@
     "express-bunyan-logger": "^1.3.3",
     "fast-levenshtein": "^3.0.0",
     "joi": "^17.3.0",
+    "moment": "^2.29.1",
     "ms": "^2.1.2",
     "socket.io": "^2.3.0",
     "uuid": "^8.3.1"

--- a/shared/protocol.js
+++ b/shared/protocol.js
@@ -16,4 +16,5 @@ export default {
   RESET: 'RESET',
   ROUND_TIMER: 'ROUND_TIMER',
   CLOSE_GUESS: 'CLOSE_GUESS',
+  GAME_OVER: 'GAME_OVER',
 };


### PR DESCRIPTION
This adds support for actually ending a game. Currently this only happens
when a game with a predifined end time reaches its end. Once the last round
has come to an end we draw the leaderboard and open up the canvas for drawing
again. The points will be shown until a new game is started.

Fixes #12
![image](https://user-images.githubusercontent.com/1607339/99914843-0c9c1800-2cf8-11eb-8231-42c495903b58.png)