### PR TITLE
Replace moment with date-fns

### DIFF
--- a/client/components/App.js
+++ b/client/components/App.js
@@ -5,7 +5,7 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/core/styles';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
-import MomentUtils from '@date-io/moment';
+import DateFnsUtils from '@date-io/date-fns';
 import mainTheme from '../theme';
 import LandingPage from './LandingPage';
 import GamePage from './GamePage';
@@ -19,7 +19,7 @@ export default ({ history }) => {
 
   return <ConnectedRouter history={history}>
     <ThemeProvider theme={mainTheme(prefersDarkMode)}>
-      <MuiPickersUtilsProvider utils={MomentUtils}>
+      <MuiPickersUtilsProvider utils={DateFnsUtils}>
         <CssBaseline />
         <Switch>
           <Route path='/' exact={true} component={LandingPage} />

--- a/client/components/StartGameDialog.js
+++ b/client/components/StartGameDialog.js
@@ -1,5 +1,12 @@
 import React from 'react';
-import moment from 'moment';
+import {
+  addDays,
+  addHours,
+  addMinutes,
+  differenceInDays,
+  differenceInMinutes,
+  startOfHour
+} from 'date-fns';
 import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
@@ -52,15 +59,15 @@ const useStyles = makeStyles((theme) => ({
 const DEFAULT_TURN_TIME_LIMIT_SECONDS = 90;
 
 const getNextHour = () => {
-  const now = moment();
-  return now.add(1, 'hour').startOf('hour');
+  const now = new Date();
+  return startOfHour(addHours(now, 1));
 };
 
 const getDurationInMinutes = (end) => {
   if (!end) return null;
-  const now = moment();
-  if (end < now) end = end.clone().add(1, 'day');
-  return Math.round(moment.duration(end.diff(now)).asMinutes());
+  const now = new Date();
+  if (end < now) end = addDays(end, 1);
+  return differenceInMinutes(end, now);
 };
 
 const StartGameDialog = ({ starting, startGame, setStarting }) => {
@@ -76,16 +83,15 @@ const StartGameDialog = ({ starting, startGame, setStarting }) => {
       return;
     }
 
-    const nextLimit = limit.clone();
-    const diffDays = moment.duration(nextLimit.diff(moment())).asDays();
-    nextLimit.subtract(Math.floor(diffDays), 'days');
+    const diffDays = differenceInDays(new Date(), limit);
+    const nextLimit = addDays(limit, diffDays);
     setTimeLimit(nextLimit);
     setDurationMinutes(getDurationInMinutes(nextLimit));
   };
   const setNextHour = () => updateTimeLimit(getNextHour());
   const setUnlimited = () => updateTimeLimit(null);
-  const addMinutes = (minutes) => () => {
-    updateTimeLimit(timeLimit.clone().add(minutes, 'm'));
+  const handleAddMinutes = (minutes) => () => {
+    updateTimeLimit(addMinutes(timeLimit, minutes));
   };
   const closeDialog = () => setStarting(false);
 
@@ -144,10 +150,10 @@ const StartGameDialog = ({ starting, startGame, setStarting }) => {
       <Button size='small' variant='outlined' onClick={setNextHour}>
         Next Full Hour
       </Button>
-      <Button disabled={timeLimit === null} size='small' variant='outlined' onClick={addMinutes(-15)}>
+      <Button disabled={timeLimit === null} size='small' variant='outlined' onClick={handleAddMinutes(-15)}>
         - 15 m
       </Button>
-      <Button disabled={timeLimit === null} size='small' variant='outlined' onClick={addMinutes(15)}>
+      <Button disabled={timeLimit === null} size='small' variant='outlined' onClick={handleAddMinutes(15)}>
         + 15 m
       </Button>
     </DialogContent>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1179,10 +1179,10 @@
       "integrity": "sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==",
       "dev": true
     },
-    "@date-io/moment": {
+    "@date-io/date-fns": {
       "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-1.3.13.tgz",
-      "integrity": "sha512-3kJYusJtQuOIxq6byZlzAHoW/18iExJer9qfRF5DyyzdAk074seTuJfdofjz4RFfTd/Idk8WylOQpWtERqvFuQ==",
+      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-1.3.13.tgz",
+      "integrity": "sha512-yXxGzcRUPcogiMj58wVgFjc9qUYrCnnU9eLcyNbsQCmae4jPuZCDoIBR21j8ZURsM7GRtU62VOw5yNd4dDHunA==",
       "dev": true,
       "requires": {
         "@date-io/core": "^1.3.13"
@@ -4092,6 +4092,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
+      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
     },
     "debug": {
       "version": "2.6.9",
@@ -7246,7 +7251,8 @@
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "optional": true
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@date-io/moment": "^1.3.13",
+    "@date-io/date-fns": "^1.3.13",
     "@hot-loader/react-dom": "^16.14.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
@@ -70,12 +70,12 @@
     "bunyan-debug-stream": "^2.0.0",
     "compression": "^1.7.4",
     "cross-env": "^7.0.2",
+    "date-fns": "^2.16.1",
     "dotenv-defaults": "^2.0.1",
     "express": "^4.17.1",
     "express-bunyan-logger": "^1.3.3",
     "fast-levenshtein": "^3.0.0",
     "joi": "^17.3.0",
-    "moment": "^2.29.1",
     "ms": "^2.1.2",
     "socket.io": "^2.3.0",
     "uuid": "^8.3.1"

--- a/server/Game.js
+++ b/server/Game.js
@@ -1,5 +1,5 @@
 import levenshtein from 'fast-levenshtein';
-import moment from 'moment';
+import { addMinutes } from 'date-fns';
 import { PING_TIMEOUT, SELECT_WORD_TIMEOUT, TICK_TIMEOUT } from '../shared/constants';
 import protocol from '../shared/protocol';
 
@@ -76,7 +76,7 @@ export default class {
       Math.round(TICK_TIMEOUT / 1000),
     ];
     this.roundTimeoutSeconds = turnTimeLimitSeconds;
-    if (durationMinutes) this.endTime = moment().add(durationMinutes, 'minutes');
+    if (durationMinutes) this.endTime = addMinutes(new Date(), durationMinutes);
     for (const player of this.players) {
       player.reset();
     }
@@ -125,7 +125,7 @@ export default class {
     this.roundTime = this.roundTimeoutSeconds;
 
     const roundFinished = meta && meta.reason !== 'SKIPPED';
-    if (roundFinished && this.started && this.endTime && moment() >= this.endTime) {
+    if (roundFinished && this.started && this.endTime && new Date() >= this.endTime) {
       this.gameOver(meta);
       return;
     }


### PR DESCRIPTION
As moment.js is deprecated nowadays replace it with date-fns which
should even reduce the bundle size as we only need a small part of it.

Fixes #32